### PR TITLE
✨ 추천 기능에 필요한 Entity 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 
 ### Spring Boot ###
 /src/main/resources/application.properties
+/src/test/resources/application-test.properties

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ java {
 }
 
 configurations {
+    all {
+        exclude group : 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
     compileOnly {
         extendsFrom annotationProcessor
     }

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ ext {
 dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation "org.springframework.boot:spring-boot-starter-web:${springVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-data-jpa${springVersion}"
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springVersion}"
     implementation "org.springframework.boot:spring-boot-starter-data-redis:${springVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-log4j2${springVersion}"
+    implementation "org.springframework.boot:spring-boot-starter-log4j2:${springVersion}"
     developmentOnly "org.springframework.boot:spring-boot-devtools:${springVersion}"
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGame.java
+++ b/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGame.java
@@ -1,0 +1,23 @@
+package com.yeoboge.recommendation.core.boardgame;
+
+import com.yeoboge.recommendation.core.bookmark.Bookmark;
+import com.yeoboge.recommendation.core.common.GenreConvertor;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "board_game")
+public class BoardGame {
+    @Id
+    @Column(name = "board_game_id")
+    private Long id;
+    private String name;
+    @Convert(converter = GenreConvertor.class)
+    private Genre genre;
+
+    @OneToMany(mappedBy = "boardGame", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks;
+}

--- a/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGame.java
+++ b/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGame.java
@@ -16,6 +16,7 @@ public class BoardGame {
     private Long id;
     private String name;
     @Convert(converter = GenreConvertor.class)
+    @Column(name = "genre_code")
     private Genre genre;
 
     @OneToMany(mappedBy = "boardGame", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGameRepository.java
+++ b/src/main/java/com/yeoboge/recommendation/core/boardgame/BoardGameRepository.java
@@ -1,0 +1,8 @@
+package com.yeoboge.recommendation.core.boardgame;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardGameRepository extends JpaRepository<BoardGame, Long> {
+}

--- a/src/main/java/com/yeoboge/recommendation/core/boardgame/Genre.java
+++ b/src/main/java/com/yeoboge/recommendation/core/boardgame/Genre.java
@@ -1,0 +1,28 @@
+package com.yeoboge.recommendation.core.boardgame;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum Genre {
+    THEMATIC(1, "테마"),
+    STRATEGY(2, "전략"),
+    WAR(3, "전쟁"),
+    FAMILY(4, "가족"),
+    ABSTRACT(5, "단순"),
+    PARTY(6, "파티"),
+    CHILDREN(7, "키즈");
+
+    private final int code;
+    private final String name;
+
+    public static Genre ofCode(int code) {
+        return Arrays.stream(Genre.values())
+                .filter(g -> g.getCode() == code)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/main/java/com/yeoboge/recommendation/core/bookmark/Bookmark.java
+++ b/src/main/java/com/yeoboge/recommendation/core/bookmark/Bookmark.java
@@ -1,0 +1,21 @@
+package com.yeoboge.recommendation.core.bookmark;
+
+import com.yeoboge.recommendation.core.boardgame.BoardGame;
+import com.yeoboge.recommendation.core.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Bookmark {
+    @Id
+    @Column(name = "bookmark_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_game_id")
+    private BoardGame boardGame;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/yeoboge/recommendation/core/common/GenreConvertor.java
+++ b/src/main/java/com/yeoboge/recommendation/core/common/GenreConvertor.java
@@ -1,0 +1,18 @@
+package com.yeoboge.recommendation.core.common;
+
+import com.yeoboge.recommendation.core.boardgame.Genre;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class GenreConvertor implements AttributeConverter<Genre, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(Genre attribute) {
+        return attribute.getCode();
+    }
+
+    @Override
+    public Genre convertToEntityAttribute(Integer dbData) {
+        return Genre.ofCode(dbData);
+    }
+}

--- a/src/main/java/com/yeoboge/recommendation/core/user/FavoriteGenre.java
+++ b/src/main/java/com/yeoboge/recommendation/core/user/FavoriteGenre.java
@@ -1,0 +1,19 @@
+package com.yeoboge.recommendation.core.user;
+
+import com.yeoboge.recommendation.core.boardgame.Genre;
+import com.yeoboge.recommendation.core.common.GenreConvertor;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "favorite_genre")
+public class FavoriteGenre {
+    @Id
+    @Column(name = "favorite_genre_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @Convert(converter = GenreConvertor.class)
+    private Genre genreCode;
+}

--- a/src/main/java/com/yeoboge/recommendation/core/user/User.java
+++ b/src/main/java/com/yeoboge/recommendation/core/user/User.java
@@ -1,0 +1,18 @@
+package com.yeoboge.recommendation.core.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+
+@Entity
+@Getter
+public class User {
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+    private String nickname;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FavoriteGenre> favoriteGenres;
+}

--- a/src/main/java/com/yeoboge/recommendation/core/user/UserRepository.java
+++ b/src/main/java/com/yeoboge/recommendation/core/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.yeoboge.recommendation.core.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/test/java/com/yeoboge/recommendation/core/BoardGameRepositoryTest.java
+++ b/src/test/java/com/yeoboge/recommendation/core/BoardGameRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.yeoboge.recommendation.core;
+
+import com.yeoboge.recommendation.core.boardgame.BoardGame;
+import com.yeoboge.recommendation.core.boardgame.BoardGameRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class BoardGameRepositoryTest {
+    @Autowired
+    private BoardGameRepository repository;
+
+    @Test
+    @DisplayName("보드게임 단일 조회 테스트")
+    public void select_board_game_by_id() {
+        // given
+        long boardGameId = 1;
+
+        // when
+        Optional<BoardGame> actual = repository.findById(boardGameId);
+
+        // then
+        assert actual.isPresent();
+    }
+}

--- a/src/test/java/com/yeoboge/recommendation/core/UserRepositoryTest.java
+++ b/src/test/java/com/yeoboge/recommendation/core/UserRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.yeoboge.recommendation.core;
+
+import com.yeoboge.recommendation.core.user.User;
+import com.yeoboge.recommendation.core.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class UserRepositoryTest {
+    @Autowired
+    private UserRepository repository;
+
+    @Test
+    @DisplayName("사용자 단일 조회 테스트")
+    public void select_user_by_id() {
+        // given
+        long userId = 1;
+
+        // when
+        Optional<User> user = repository.findById(userId);
+
+        // then
+        assert user.isPresent();
+    }
+}


### PR DESCRIPTION
### 작업 내용

- 추천 기능에 필요한 기본 Entity(BoardGame, User, Bookmark) 추가
- 기존 방식과 달리 Genre는 enum으로 관리
- JpaRepository 연결

### 관련 이슈
closes #2 